### PR TITLE
Table width calculation: fix calculation of "px" widths

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.2.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Table width calculation: treat "px" the same as widths without measure units.
+  [jone]
 
 
 1.2.6 (2013-04-17)

--- a/ftw/pdfgenerator/html2latex/subconverters/table.py
+++ b/ftw/pdfgenerator/html2latex/subconverters/table.py
@@ -886,6 +886,11 @@ class LatexWidth(object):
         creates a LatexWidth object by a HTML width-Attribute
         """
 
+        # px is the same as no measure unit, so we can strip it.
+        width = width.strip()
+        if width.endswith('px'):
+            width = width.rstrip('px')
+
         # absolute
         for unit in cls.VALID_ABSOLUTE_UNITS:
             match = re.compile('^([0-9,\.]{1,})(%s)$' % unit).match(width)

--- a/ftw/pdfgenerator/tests/test_html2latex_table_converter.py
+++ b/ftw/pdfgenerator/tests/test_html2latex_table_converter.py
@@ -238,6 +238,41 @@ class TestTableConverter(MockTestCase):
 
         self.assertEqual(self.convert(html), latex)
 
+    def test_style_widths_in_px(self):
+
+        html = '\n'.join((
+                r'<table>',
+                r'    <tbody>',
+                r'        <tr>',
+                r'            <td align="right" style="width:30px">test1</td>',
+                r'            <td align="left" ' +
+                r'style="color: red; width: 70px;">test2</td>',
+                r'        </tr><tr>',
+                r'            <td align="center">test3</td>',
+                r'            <td>test4</td>',
+                r'        </tr>',
+                r'    </tbody>',
+                r'</table>'))
+
+        latex = '\n'.join((
+                r'\makeatletter\@ifundefined{tablewidth}{' +
+                r'\newlength\tablewidth}\makeatother',
+                r'\setlength\tablewidth\linewidth',
+                r'\addtolength\tablewidth{-4\tabcolsep}',
+                r'\begin{tabular}{p{30.0em}p{70.0em}}',
+
+                r'\multicolumn{1}{p{30.0em}}{'
+                r'\raggedleft test1} & \multicolumn{1}{'
+                r'p{70.0em}}{\raggedright test2} \\',
+
+                r'\multicolumn{1}{p{30.0em}}{\centering '
+                r'test3} & \multicolumn{1}{p{70.0em}}{test4} \\',
+
+                r'\end{tabular}',
+                r''))
+
+        self.assertEqual(self.convert(html), latex)
+
 
     def test_caption_is_used(self):
         # The table caption is used and will be shown in the table index
@@ -1428,6 +1463,12 @@ class TestLatexWidth(TestCase):
                          r'123.1mm')
         self.assertEqual(str(width2 + width1),
                          r'123.1mm')
+
+    def test_px_is_the_same_as_no_measure_unit(self):
+        width_px = table.LatexWidth.convert('50px')
+        width_no = table.LatexWidth.convert('50')
+
+        self.assertEqual(str(width_no), str(width_px))
 
     def test_fails_if_summing_with_non_width(self):
         width = table.LatexWidth.convert('10.3cm')


### PR DESCRIPTION
Treat "px" the same as with no measurement unit.
Using "em" for "px" is still not quite right, but using px's in printed media is anyway not right at all.
But this allows us to be better compatible with WYSIWYG editors for web content, which the is converted..

/cc @maethu 
