### PR TITLE
Use non-breaking spaces and en-dashes for formatting swiss currency.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.2.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use non-breaking spaces and en-dashes for formatting swiss currency.
+  [jone]
 
 
 1.2.7 (2013-05-24)

--- a/ftw/pdfgenerator/html2latex/patterns.py
+++ b/ftw/pdfgenerator/html2latex/patterns.py
@@ -8,6 +8,8 @@ MODE_REGEXP = interfaces.HTML2LATEX_MODE_REGEXP
 MODE_REGEXP_FUNCTION = interfaces.HTML2LATEX_MODE_REGEXP_FUNCTION
 BACKSLASH_MARKER = 'THISISABACKSLASH' * 2
 
+DASH = '\xe2\x80\x93'  # &ndash;
+
 
 DEFAULT_PATTERNS = ([
         (MODE_REPLACE,  '\\',                      BACKSLASH_MARKER),
@@ -360,6 +362,11 @@ DEFAULT_PATTERNS = ([
         (MODE_REPLACE,  'z. B.',                   'z.\,B.'),
         (MODE_REPLACE,  'lic.iur.',                'lic.\,iur.'),
         (MODE_REPLACE,  'Dr.iur.',                 'Dr.\,iur.'),
+
+        # Use dashes and non breaking space in swiss currencies
+        (MODE_REGEXP, r'Fr\.[ ~](\d{1,})\.(%s|-{1,2})' % DASH,
+                      r'Fr.~\1.--'),
+
 
         # date replacements: we use nonbreakable spaces
         # TODO: make regexp patterns or subconverter

--- a/ftw/pdfgenerator/tests/test_html2latex_patterns.py
+++ b/ftw/pdfgenerator/tests/test_html2latex_patterns.py
@@ -1013,3 +1013,19 @@ class TestBasicPatterns(TestCase):
 
         self.assertEqual(self.convert(u'\u2282'.encode('utf-8')),
                          r'$\subset$')
+
+    def test_swiss_currency_with_dash(self):
+        self.assertEqual([
+                'Fr.~0.--',
+                'Fr.~123.--',
+                'Fr.~45.--',
+                'Fr.~67.--',
+                'Fr. .-',
+
+             ], [
+                self.convert('Fr. 0.-'),
+                self.convert('Fr. 123.-'),
+                self.convert('Fr. 45.--'),
+                self.convert('Fr. 67.\xe2\x80\x93'),
+                self.convert('Fr. .-'),
+                ])


### PR DESCRIPTION
For swiss currencies we should use n-dashes instead of hyphens, e.g. `Fr. 10.–` instead of `Fr. 10.-` or `Fr. 10.--`.
Also use non-breaking spaces after `Fr.`.

@buchi Do you think that is the correct way to do it?
