### PR TITLE
Fix LaTeX "no line here to end" problem with newlines within text commands

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.2.9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix LaTeX "no line here to end" problem with newlines within text commands.
+  [jone]
 
 
 1.2.8 (2013-10-21)

--- a/ftw/pdfgenerator/html2latex/subconverters/textformatting.py
+++ b/ftw/pdfgenerator/html2latex/subconverters/textformatting.py
@@ -29,6 +29,11 @@ class Textformatting(subconverter.SubConverter):
     "\textbf{*\n\n*}" is not allowed, use "\textbf{*\\*}"
     "\textit{*\n\n*}" is not allowed, use "\textit{*\\*}"
     "\emph{*\n\n*}" is not allowed, use "\emph{*\\*}"
+
+    It also not allowed to have multiple newlines (\\{1,}) in those
+    environments.
+    Since we sometimes we have this situation and we cannot end the
+    paragraph we need to fix it with \vspace's.
     """
 
     pattern = r'(\\(textbf|textit|emph){.*})'
@@ -48,4 +53,9 @@ class Textformatting(subconverter.SubConverter):
         self.replace(latex)
 
     def convert_substring(self, latex):
-        return latex.replace('\n\n', r'\\\\')
+        latex = latex.replace(r'\\', '\n')
+
+        latex = re.sub(r'([^\n])\n', r'\g<1>\\\\', latex)
+        latex = re.sub(r'\n+', r'\\vspace{\\baselineskip}', latex)
+
+        return latex

--- a/ftw/pdfgenerator/tests/test_html2latex_patterns.py
+++ b/ftw/pdfgenerator/tests/test_html2latex_patterns.py
@@ -135,20 +135,20 @@ class TestBasicPatterns(TestCase):
                          '\\textbf{zwei}\\\\\nzwei')
 
         self.assertEqual(self.convert('<b>drei<br /></b>'),
-                         '\\textbf{drei\\\\\n}')
+                         '\\textbf{drei\\\\\\vspace{\\baselineskip}}')
 
         self.assertEqual(self.convert('<b>vier<br />\n</b>'),
-                         '\\textbf{vier\\\\\n }')
+                         '\\textbf{vier\\\\\\vspace{\\baselineskip} }')
 
         self.assertEqual(self.convert('<b>fuenf<br />\n</b><br />'),
-                         '\\textbf{fuenf\\\\\n }')
+                         '\\textbf{fuenf\\\\\\vspace{\\baselineskip} }')
 
         self.assertEqual(self.convert('<b>sechs<br />\n</b>sechs<br />'),
-                         '\\textbf{sechs\\\\\n }sechs')
+                         '\\textbf{sechs\\\\\\vspace{\\baselineskip} }sechs')
 
         self.assertEqual(self.convert('<strong>&quot;sieben&quot;<br />\n'
                                       '</strong><br />'),
-                         '\\textbf{"`sieben"\'\\\\\n }')
+                         '\\textbf{"`sieben"\'\\\\\\vspace{\\baselineskip} }')
 
     def test_abbreviations_are_not_breakable(self):
         self.maxDiff = None
@@ -208,6 +208,16 @@ class TestBasicPatterns(TestCase):
 
         self.assertEqual(self.convert('<p><strong><br />Text</strong></p>'),
                          r'\textbf{Text}')
+
+    def test_no_double_newlines_within_textbf_command(self):
+        """Within a \textbf command, it is not allowed to finish a
+        paragraph with either \par or \n\n.
+        It is also not allowed to make two newlines (\\\\ or \\\newline).
+        Thus, when we need to have an empty line, we use the workaround
+        \vspace{\baselineskip} after the first newline.
+        """
+        self.assertEqual(self.convert('<strong>foo<br /><br />bar</strong>'),
+                         r'\textbf{foo\\\vspace{\baselineskip}bar}')
 
     def test_curly_bracket_spaces(self):
         # If there is no space at left of the curly brackets, there will

--- a/ftw/pdfgenerator/tests/test_textformatting_converter.py
+++ b/ftw/pdfgenerator/tests/test_textformatting_converter.py
@@ -35,55 +35,55 @@ class TestTextformattingConverter(SubconverterTestBase):
         # "\textbf{X\n\n}" is not allowed, use "\textbf{X\\}"
         self.assertEqual(
             self.convert(r'<p><b>foo<br /> <br /></b></p>'),
-            r'\textbf{foo\\\\}')
+            r'\textbf{foo\\\vspace{\baselineskip}}')
 
     def test_newline_in_bold_command2(self):
         # "\textbf{X\n\nY}" is not allowed, use "\textbf{X\\Y}"
         self.assertEqual(
             self.convert(r'<p><b>foo<br /> <br />bar</b></p>'),
-            r'\textbf{foo\\\\bar}')
+            r'\textbf{foo\\\vspace{\baselineskip}bar}')
 
     def test_newline_in_bold_command3(self):
         # "\textbf{\n\nY}" is not allowed, use "\textbf{\\Y}"
         self.assertEqual(
             self.convert(r'<b><br /> <br />bar</b>' * 2),
-            r'\textbf{\\\\bar}' * 2)
+            r'\textbf{\\\vspace{\baselineskip}bar}' * 2)
 
     def test_newline_in_emph_command(self):
         # "\emph{X\n\n}" is not allowed, use "\emph{X\\}"
         self.assertEqual(
             self.convert(r'foo <u>bar<br /> <br /></u> baz'),
-            r'foo \emph{bar\\\\} baz')
+            r'foo \emph{bar\\\vspace{\baselineskip}} baz')
 
     def test_newline_in_emph_command2(self):
         # "\emph{X\n\nY}" is not allowed, use "\emph{X\\Y}"
         self.assertEqual(
             self.convert(r'<u>foo<br /> <br />bar</u>'),
-            r'\emph{foo\\\\bar}')
+            r'\emph{foo\\\vspace{\baselineskip}bar}')
 
     def test_newline_in_emph_command3(self):
         # "\emph{\n\nY}" is not allowed, use "\emph{\\Y}"
         self.assertEqual(
             self.convert(r'<u><br /> <br />bar</u>' * 2),
-            r'\emph{\\\\bar}' * 2)
+            r'\emph{\\\vspace{\baselineskip}bar}' * 2)
 
     def test_newline_in_italic_command(self):
         # "\textit{X\n\n}" is not allowed, use "\textit{X\\}"
         self.assertEqual(
             self.convert(r'<p><i>foo<br /> <br /></i></p>'),
-            r'\textit{foo\\\\}')
+            r'\textit{foo\\\vspace{\baselineskip}}')
 
     def test_newline_in_italic_command2(self):
         # "\textit{X\n\nY}" is not allowed, use "\textit{X\\Y}"
         self.assertEqual(
             self.convert(r'<p><i>foo<br /> <br />bar</i></p>'),
-            r'\textit{foo\\\\bar}')
+            r'\textit{foo\\\vspace{\baselineskip}bar}')
 
     def test_newline_in_italic_command3(self):
         # "\textit{\n\nY}" is not allowed, use "\textit{\\Y}"
         self.assertEqual(
             self.convert(r'<i><br /> <br />bar</i>' * 2),
-            r'\textit{\\\\bar}' * 2)
+            r'\textit{\\\vspace{\baselineskip}bar}' * 2)
 
     def test_newline_in_combined_italic_and_bold_command(self):
         # "\textit{*\n\n*}" is not allowed, use "\textit{*\\*}"
@@ -93,11 +93,12 @@ class TestTextformattingConverter(SubconverterTestBase):
                          r'<b>bar</b><br /> <br />'
                          r'<u>baz</u><br /> <br />'
                          r'</i>'),
-            r'\textit{foo\textbf{bar}\\\\\emph{baz}\\\\}')
+            r'\textit{foo\textbf{bar}\\\vspace{\baselineskip}'
+            r'\emph{baz}\\\vspace{\baselineskip}}')
 
         self.assertEqual(
             self.convert(r'<b>foo<i>bar</i><br /> <br /></b>'),
-            r'\textbf{foo\textit{bar}\\\\}')
+            r'\textbf{foo\textit{bar}\\\vspace{\baselineskip}}')
 
     def test_newline_only_in_textish_environments_changed(self):
         self.assertEqual(


### PR DESCRIPTION
:construction: 

``` latex
\textbf{foo\n\nbar}  % LaTeX Error: Paragraph ended before \text@command was complete.
\textbf{foo\\\\bar}  % LaTeX Error: There's no line here to end.
\textbf{foo\\\vspace{\baselineskip}bar} % works, but is a hack
```

This change makes line breaks in the text commands be converted to vspace's as in the last example.
