### PR TITLE
Table: fix error where rowspan cells made other cells swap rows.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.2.9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Table: fix error where rowspan cells made other cells swap rows.
+  [jone]
 
 
 1.2.8 (2013-10-21)

--- a/ftw/pdfgenerator/html2latex/subconverters/table.py
+++ b/ftw/pdfgenerator/html2latex/subconverters/table.py
@@ -4,6 +4,7 @@ from ftw.pdfgenerator.html2latex import subconverter
 from ftw.pdfgenerator.html2latex import wrapper
 from ftw.pdfgenerator.html2latex.utils import generate_manual_caption
 from ftw.pdfgenerator.utils import html2xmlentities
+from operator import methodcaller
 from xml.dom import minidom
 import re
 
@@ -266,9 +267,9 @@ class TableConverter(subconverter.SubConverter):
             }
 
         for domTr in self.dom.getElementsByTagName('tr'):
-            self._parse_tr_dom(domTr, multi_row_cache)
+            self._parse_tr_dom(domTr, multi_row_cache, amount)
 
-    def _parse_tr_dom(self, domTr, multi_row_cache):
+    def _parse_tr_dom(self, domTr, multi_row_cache, amount_of_columns):
         row = self.create_latex_row(domTr=domTr)
         self.rows.append(row)
 
@@ -282,7 +283,8 @@ class TableConverter(subconverter.SubConverter):
         columnIndex = 0
         cell_index = 0
 
-        while len(cells) > cell_index:
+        while sum(map(methodcaller('get_colspan'), row.cells)) < \
+                amount_of_columns:
             if columnIndex in multi_row_cache.keys():
                 multi_row_cache[columnIndex][0].register_row(row)
                 multi_row_cache[columnIndex][1] -= 1

--- a/ftw/pdfgenerator/tests/test_html2latex_table_converter.py
+++ b/ftw/pdfgenerator/tests/test_html2latex_table_converter.py
@@ -643,6 +643,49 @@ class TestTableConverter(MockTestCase):
         self.maxDiff = None
         self.assertMultiLineEqual(self.convert(html), latex)
 
+    def test_rowspan_error_in_last_column(self):
+        # Regression test that cells do not swap rows.
+
+        html = '\n'.join((
+                r'<table>',
+                r'    <colspan>',
+                r'        <col width="50%" />',
+                r'        <col width="50%" />',
+                r'    </colspan>',
+                r'    <tbody>',
+                r'        ',
+                r'        <tr>',
+                r'            <td>A</td>',
+                r'            <td rowspan="2">2xB</td>',
+                r'        </tr>',
+                r'        <tr>',
+                r'            <td>A</td>',
+                r'        </tr>',
+                r'        <tr>',
+                r'            <td>A</td>',
+                r'            <td>B</td>',
+                r'        </tr>',
+                r'        ',
+                r'    </tbody>',
+                r'</table>'))
+
+        latex = '\n'.join((
+                r'\makeatletter\@ifundefined{tablewidth}{' + \
+                    r'\newlength\tablewidth}\makeatother',
+                r'\setlength\tablewidth\linewidth',
+                r'\addtolength\tablewidth{-4\tabcolsep}',
+                r'\begin{tabular}{p{0.5\tablewidth}p{0.5\tablewidth}}',
+                r'\multicolumn{1}{p{0.5\tablewidth}}{A} &' + \
+                    r' \multirow{2}{0.5\tablewidth}{2xB} \\',
+                r'\multicolumn{1}{p{0.5\tablewidth}}{A} &  \\',
+                r'\multicolumn{1}{p{0.5\tablewidth}}{A} &' + \
+                    r' \multicolumn{1}{p{0.5\tablewidth}}{B} \\',
+                r'\end{tabular}',
+                r''))
+
+        self.maxDiff = None
+        self.assertMultiLineEqual(self.convert(html), latex)
+
     def test_gridborder(self):
 
         html = '\n'.join((


### PR DESCRIPTION
This is an error while parsing the table.
When the parsing each row and assigning the columns the wrong while loop condition caused the loop to stop early and not consume rowspan cells from prior rows when the rowspan cell is in the last column.
