### PR TITLE
Hyperlinks in footnotes: use \url instead of manual hyphenation hints.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,11 @@ Changelog
 1.2.9 (unreleased)
 ------------------
 
+- Hyperlinks in footnotes: use \url instead of manual hyphenation hints.
+  This fixes that "" is visible in footer urls with certain hyperref
+  package versions.
+  [jone]
+
 - Table: fix error where rowspan cells made other cells swap rows.
   [jone]
 

--- a/ftw/pdfgenerator/html2latex/subconverters/hyperlink.py
+++ b/ftw/pdfgenerator/html2latex/subconverters/hyperlink.py
@@ -27,19 +27,15 @@ class HyperlinkConverter(subconverter.SubConverter):
         url = url.replace(' ', '%20').replace('%', '\%')
         url = url.replace('_', '\_').replace('#', '\#')
 
-        # hyphenation: "" allows latex to insert a word wrap at this
-        # position without adding a hyphen.
-        url_label = url.replace('/', '/""')
-        url_label = url_label.replace(':/""/""', '://')
-        url_label = re.sub('/""$', '/', url_label)
-        url_label = re.sub('^mailto:', '', url_label)
+        # Do not display "mailto:"
+        url_label = re.sub('^mailto:', '', url)
 
         self.get_layout().use_package('hyperref')
         self.replace_and_lock(self.latex_link(url, label, url_label))
 
     def latex_link(self, url, label, url_label):
         href = r'\href{%s}{%s}'
-        footnote = r'\footnote{%s}' % href % (url, url_label)
+        footnote = r'\footnote{%s}' % href % (url, r'\url{%s}' % url_label)
         return href % (url, label + footnote)
 
     def resolve_uid(self, url):

--- a/ftw/pdfgenerator/tests/test_html2latex_hyperlink_converter.py
+++ b/ftw/pdfgenerator/tests/test_html2latex_hyperlink_converter.py
@@ -7,7 +7,7 @@ from ftw.testing import MockTestCase
 
 
 LATEX_HREF = r'\href{%(url)s}{%(label)s\footnote{\href{%(url)s}' + \
-    r'{%(url_label)s}}}'
+    r'{\url{%(url_label)s}}}}'
 
 
 class TestHyperlinkConverter(MockTestCase):
@@ -46,14 +46,14 @@ class TestHyperlinkConverter(MockTestCase):
         latex = LATEX_HREF % {
             'label': 'baz',
             'url': 'http://nohost/plone/foo/bar',
-            'url_label': 'http://nohost/""plone/""foo/""bar'}
+            'url_label': 'http://nohost/plone/foo/bar'}
         self.assertEqual(self.convert(html), latex)
 
         html = '<a href="foo/bar">baz</a>'
         latex = LATEX_HREF % {
             'label': 'baz',
             'url': 'http://nohost/plone/foo/bar',
-            'url_label': 'http://nohost/""plone/""foo/""bar'}
+            'url_label': 'http://nohost/plone/foo/bar'}
         self.assertEqual(self.convert(html), latex)
 
     def test_links_within_brackets(self):
@@ -87,7 +87,7 @@ class TestHyperlinkConverter(MockTestCase):
         latex = LATEX_HREF % {
             'label': 'foo',
             'url': 'http://foo/foo\%20bar\%20baz',
-            'url_label': 'http://foo/""foo\%20bar\%20baz'}
+            'url_label': 'http://foo/foo\%20bar\%20baz'}
         self.assertEqual(self.convert(html), latex)
 
         html = '<a href="mailto:info@google.com?subject=foo%20bar%20baz">' +\
@@ -110,13 +110,13 @@ class TestHyperlinkConverter(MockTestCase):
         html = '<a href="http://host.com/?foo=1&amp;bar=2">baz</a>'
         latex = LATEX_HREF % {'label': 'baz',
                               'url': 'http://host.com/?foo=1\\&bar=2',
-                              'url_label': 'http://host.com/""?foo=1\\&bar=2'}
+                              'url_label': 'http://host.com/?foo=1\\&bar=2'}
         self.assertEqual(self.convert(html), latex)
 
         html = '<a href="http://host.com/?foo=1&bar=2">baz</a>'
         latex = LATEX_HREF % {'label': 'baz',
                               'url': 'http://host.com/?foo=1\\&bar=2',
-                              'url_label': 'http://host.com/""?foo=1\\&bar=2'}
+                              'url_label': 'http://host.com/?foo=1\\&bar=2'}
         self.assertEqual(self.convert(html), latex)
 
     def test_underscores_in_links(self):
@@ -124,7 +124,7 @@ class TestHyperlinkConverter(MockTestCase):
         html = '<a href="http://host.com/foo_bar">baz</a>'
         latex = LATEX_HREF % {'label': 'baz',
                               'url': 'http://host.com/foo\\_bar',
-                              'url_label': 'http://host.com/""foo\\_bar'}
+                              'url_label': 'http://host.com/foo\\_bar'}
         self.assertEqual(self.convert(html), latex)
 
     def test_hash_key_in_links(self):
@@ -132,7 +132,7 @@ class TestHyperlinkConverter(MockTestCase):
         html = '<a href="http://host.com/foo#bar">baz</a>'
         latex = LATEX_HREF % {'label': 'baz',
                               'url': 'http://host.com/foo\\#bar',
-                              'url_label': 'http://host.com/""foo\\#bar'}
+                              'url_label': 'http://host.com/foo\\#bar'}
         self.assertEqual(self.convert(html), latex)
 
     def test_additional_parameters(self):
@@ -142,7 +142,7 @@ class TestHyperlinkConverter(MockTestCase):
         latex = r'foo %s baz' % LATEX_HREF % {
             'label': 'bar',
             'url': 'http://nohost/bar',
-            'url_label': 'http://nohost/""bar'}
+            'url_label': 'http://nohost/bar'}
 
         self.assertEqual(self.convert(html), latex)
 
@@ -175,7 +175,7 @@ class TestHyperlinkConverter(MockTestCase):
             html = '<a href="%s://foo/bar">baz</a>' % protocol
             latex = LATEX_HREF % {'label': 'baz',
                                   'url': '%s://foo/bar' % protocol,
-                                  'url_label': '%s://foo/""bar' % protocol}
+                                  'url_label': '%s://foo/bar' % protocol}
             self.assertEqual(self.convert(html), latex)
 
     def test_label_is_converted(self):
@@ -206,13 +206,13 @@ class TestHyperlinkConverter(MockTestCase):
         html = '<a href="./resolveuid/THEUID">The Obj</a>'
         latex = LATEX_HREF % {'label': 'The Obj',
                               'url': 'http://nohost/theobj',
-                              'url_label': 'http://nohost/""theobj'}
+                              'url_label': 'http://nohost/theobj'}
         self.assertEqual(self.convert(html), latex)
 
         html = '<a href="./resolveUid/THEUID">The Obj</a>'
         latex = LATEX_HREF % {'label': 'The Obj',
                               'url': 'http://nohost/theobj',
-                              'url_label': 'http://nohost/""theobj'}
+                              'url_label': 'http://nohost/theobj'}
         self.assertEqual(self.convert(html), latex)
 
     def test_links_in_listing_items(self):
@@ -226,7 +226,7 @@ class TestHyperlinkConverter(MockTestCase):
         latex_link = LATEX_HREF % {
             'label': 'foo bar',
             'url': 'http://host/view?foo=1\\&bar=2',
-            'url_label': 'http://host/""view?foo=1\\&bar=2'}
+            'url_label': 'http://host/view?foo=1\\&bar=2'}
 
         latex = '\n'.join((
                 r'\begin{enumerate}',


### PR DESCRIPTION
This fixes that `""` is visible in footer urls with certain hyperref package versions.
