### PR TITLE
LaTeX: use math mode for asterisks (*), so they get no longer swallowed.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.2.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- LaTeX: use math mode for asterisks (*), so they get no longer swallowed.
+  [jone]
 
 
 1.2.9 (2014-01-17)

--- a/ftw/pdfgenerator/html2latex/patterns.py
+++ b/ftw/pdfgenerator/html2latex/patterns.py
@@ -113,6 +113,7 @@ DEFAULT_PATTERNS = ([
         (MODE_REPLACE,  '&euro;',                  '\\euro{}'),
         (MODE_REPLACE,  '&sect;',                  '\\S'),
         (MODE_REPLACE,  '&amp;',                   '&'),
+        (MODE_REPLACE,  '*',                       r'$\ast$'),
 
         (MODE_REPLACE,  '&lsquo;',                 '‘'),
         (MODE_REPLACE,  '&rsquo;',                 '’'),

--- a/ftw/pdfgenerator/tests/test_html2latex_patterns.py
+++ b/ftw/pdfgenerator/tests/test_html2latex_patterns.py
@@ -260,9 +260,16 @@ class TestBasicPatterns(TestCase):
             self.convert('<span style="font-weight: bold">test</span>'),
             '\\textbf{test}')
 
+    def test_asterisks(self):
+        """Asterisks (*) needs to be defined using the \ast command,
+        which does only work properly in math-environments ($$).
+        """
+        self.assertEqual(self.convert('foo * bar'),
+                         r'foo $\ast$ bar')
+
     def test_sepcial_characters(self):
-        self.assertEqual(self.convert('!#$%&amp;\'()*+-./02345'),
-                         "!\\#\\$\\%\\&'()*+-./02345")
+        self.assertEqual(self.convert('!#$%&amp;\'()+-./02345'),
+                         "!\\#\\$\\%\\&'()+-./02345")
 
         self.assertEqual(self.convert('6789:;&lt;=&gt;?@ABCDEFGHI'),
                          '6789:;<=>?@ABCDEFGHI')


### PR DESCRIPTION
Asterisks (*) are often swallowed at the moment (depending on the surrounding text), because they are not defined properly.
This changes the LaTeX markup to use math environments for asterisks:

``` latex
$\ast$
```
