### PR TITLE
Run makeindex when *.idx files were created during PDF build.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,10 @@ Changelog
 1.2.11 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Run makeindex when *.idx files were created during PDF build.
+  This allows to create indexes easily just by using the latex commands.
+  The builder takes care that the index is built and the PDF rebuilt properly.
+  [jone]
 
 
 1.2.10 (2014-02-05)

--- a/ftw/pdfgenerator/builder.py
+++ b/ftw/pdfgenerator/builder.py
@@ -89,15 +89,26 @@ class Builder(object):
         latex_file.write(latex)
         latex_file.close()
 
+        cmd = 'pdflatex --interaction=nonstopmode %s' % latex_path
         stdout = ''
         while self._rerun_required(stdout):
-            cmd = 'pdflatex --interaction=nonstopmode %s' % latex_path
             _exitcode, stdout, _stderr = self._execute(cmd)
+
+        if self._makeindex():
+            self._execute(cmd)
 
         if not os.path.exists(pdf_path):
             raise PDFBuildFailed('PDF missing.')
 
         return pdf_path
+
+    def _makeindex(self):
+        idx_path = os.path.join(self.build_directory, 'export.idx')
+        if not os.path.exists(idx_path):
+            return False
+
+        self._execute('makeindex export')
+        return True
 
     def _rerun_required(self, stdout):
         if self._rerun_limit == 0:


### PR DESCRIPTION
This allows to create indexes easily just by using the latex commands.
The builder takes care that the index is built and the PDF rebuilt properly.
## 

For creating an index in a LaTeX PDF the `\index`  and `\printindex` commands are used.
For building the index so that it can include the page numbers of occurrences, one needs to build the PDF (`pdflatex`), then build the index (`makeindex`), then again run `pdflatex` for including the built index in the PDF.

/ @maethu 
