### PR TITLE
Fix backslash LaTeX to use `\textbackslash` instead of `\\`.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix backslash LaTeX to use `\textbackslash` instead of `\\`.
+  This fixes problems with backslash in certain environments such as tables.
+  [jone]
 
 
 1.3.0 (2014-03-04)

--- a/ftw/pdfgenerator/html2latex/patterns.py
+++ b/ftw/pdfgenerator/html2latex/patterns.py
@@ -419,5 +419,5 @@ DEFAULT_PATTERNS = ([
         interfaces.HTML2LATEX_CUSTOM_PATTERN_PLACEHOLDER_BOTTOM,
         (MODE_REPLACE,  interfaces.HTML2LATEX_PREVENT_CHARACTER,         ''),
         (MODE_REPLACE,  BACKSLASH_MARKER,
-         '\\\\'),
+         r'\textbackslash '),
         ])

--- a/ftw/pdfgenerator/tests/test_html2latex_list_converter.py
+++ b/ftw/pdfgenerator/tests/test_html2latex_list_converter.py
@@ -13,7 +13,7 @@ class TestListConverter(SubconverterTestBase):
         self.assertEqual(
             self.convert('<ul><li>O:\\foo\\bar\\baz</li></ul>'),
             '\n\\begin{itemize}\n'
-            '\\item O:\\\\foo\\\\bar\\\\baz\n'
+            '\\item O:\\textbackslash foo\\textbackslash bar\\textbackslash baz\n'
             '\\end{itemize}\n')
 
         self.assertEqual(

--- a/ftw/pdfgenerator/tests/test_html2latex_patterns.py
+++ b/ftw/pdfgenerator/tests/test_html2latex_patterns.py
@@ -414,7 +414,7 @@ class TestBasicPatterns(TestCase):
 
         # Backslashes
         self.assertEqual(self.convert(r'C:\Programs\foo').strip(),
-                         r'C:\\Programs\\foo')
+                         r'C:\textbackslash Programs\textbackslash foo')
 
     def test_removes_nonbreaking_spaces(self):
         # Non break spaces are evil. In HTML they are usually not used the


### PR DESCRIPTION
This fixes problems with backslash in certain environments such as tables.
@maethu fixes some of the problems with the workspace details PDF export.
