### PR TITLE
Fix PDF rendering bug when having underscores in internal hyperlinks.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.3.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix PDF rendering bug when having underscores in internal hyperlinks.
+  [jone]
 
 
 1.3.2 (2014-06-11)

--- a/ftw/pdfgenerator/html2latex/subconverters/hyperlink.py
+++ b/ftw/pdfgenerator/html2latex/subconverters/hyperlink.py
@@ -25,10 +25,11 @@ class HyperlinkConverter(subconverter.SubConverter):
         url = url.replace('&amp;', '&')
         url = url.replace('&', '\\&')
         url = url.replace(' ', '%20').replace('%', '\%')
-        url = url.replace('_', '\_').replace('#', '\#')
+        url = url.replace('#', '\#')
 
         # Do not display "mailto:"
         url_label = re.sub('^mailto:', '', url)
+        url_label = url_label.replace('_', '\_')
 
         self.get_layout().use_package('hyperref')
         self.replace_and_lock(self.latex_link(url, label, url_label))

--- a/ftw/pdfgenerator/tests/test_html2latex_hyperlink_converter.py
+++ b/ftw/pdfgenerator/tests/test_html2latex_hyperlink_converter.py
@@ -123,7 +123,7 @@ class TestHyperlinkConverter(MockTestCase):
         self.replay()
         html = '<a href="http://host.com/foo_bar">baz</a>'
         latex = LATEX_HREF % {'label': 'baz',
-                              'url': 'http://host.com/foo\\_bar',
+                              'url': 'http://host.com/foo_bar',
                               'url_label': 'http://host.com/foo\\_bar'}
         self.assertEqual(self.convert(html), latex)
 


### PR DESCRIPTION
Fixes a bug with hyperlinks whose targets (urls or internal paths) contain underscores:
Underscores must be escaped with leading backslashes where they are displayed (e.g. link labels) but should not be escaped in the hyperlink target.
This changes removes escaping on the hyperlink target.
