### PR TITLE
Workaround for too long makeindex argument causing buffer overflow.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Workaround for too long makeindex argument causing buffer overflow.
+  [jone]
 
 
 1.3.5 (2015-02-19)

--- a/ftw/pdfgenerator/builder.py
+++ b/ftw/pdfgenerator/builder.py
@@ -113,8 +113,12 @@ class Builder(object):
         if not os.path.exists(idx_path):
             return False
 
+        # When the makeindex arguments are too long, we might get a
+        # buffer oferflow.
+        # For avoiding this, we copy the "umlaut.ist" to the export directory.
         umlaut_ist_path = os.path.join(RESOURCES_DIR, 'umlaut.ist')
-        self._execute('makeindex -g -s {0} export'.format(umlaut_ist_path))
+        shutil.copyfile(umlaut_ist_path, os.path.join(self.build_directory, 'umlaut.ist'))
+        self._execute('makeindex -g -s umlaut.ist export')
         return True
 
     def _rerun_required(self, stdout):

--- a/ftw/pdfgenerator/tests/test_builder.py
+++ b/ftw/pdfgenerator/tests/test_builder.py
@@ -313,10 +313,7 @@ class TestBuilder(MockTestCase):
         with open(idx_path, 'w+') as idx:
             idx.write('\indexentry{Test}{2}')
 
-        umlaut_ist_path = os.path.abspath(os.path.join(
-                __file__, '..', '..', 'resources', 'umlaut.ist'))
-        (self.expect(builder._execute('makeindex -g -s {0} export'.format(
-                        umlaut_ist_path)))
+        (self.expect(builder._execute('makeindex -g -s umlaut.ist export'))
          .result((0, 'stdout', 'stderr')))
 
         self.replay()


### PR DESCRIPTION
When the makeindex arguments are too long, we might get a buffer oferflow.
For avoiding this, we copy the "umlaut.ist" to the export directory.