### PR TITLE
fix table, when row has less cells than specified and no colspan is given.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.3.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix table converting when there are less cells than specified and no colspan attribute is given.
+  [tschanzt]
 
 
 1.3.7 (2015-04-13)

--- a/ftw/pdfgenerator/html2latex/subconverters/table.py
+++ b/ftw/pdfgenerator/html2latex/subconverters/table.py
@@ -94,7 +94,6 @@ class TableConverter(subconverter.SubConverter):
     def parse(self):
         html = self.get_html()
         # cleanup html with BeautifulSoup
-
         html = str(BeautifulSoup(html))
         # minidom hates htmlentities, but loves xmlentities -.-
 
@@ -297,7 +296,10 @@ class TableConverter(subconverter.SubConverter):
                 columnIndex += 1
 
             else:
-                dom_cell = cells[cell_index]
+                try:
+                    dom_cell = cells[cell_index]
+                except IndexError:
+                    break
                 cell_index += 1
                 cell = self.create_latex_cell(dom_cell=dom_cell, row=row)
                 # rowspan?
@@ -494,7 +496,6 @@ class LatexRow(object):
         line_latex = self.get_horizontal_line_latex(self.get_next_row(), self)
         if line_latex:
             latex.append(line_latex)
-
         return '\n'.join(latex) + '\n'
 
     def get_horizontal_line_latex(self, top_row, bottom_row):
@@ -984,7 +985,6 @@ def apply_borders_to_format(element, format_):
     `element` -- Cell or column object.
     `format_` -- LaTeX format definiton.
     """
-
     if element.has_left_border() and not format_.startswith('|'):
         format_ = '|%s' % format_
 


### PR DESCRIPTION
This fixes a problem when dealing with broken tables.
eg:
```
<table>
    <tr>
        <td></td>
        <td></td><!--There is no colspan set here so we are missing a cell -->
    </tr>
    <tr>
        <td></td>
        <td></td>
        <td></td>
    </tr>
</table>
```

Because the maximum width is 3 cells the pdfgenerator tries to create 3 cells for everyline except when the colspan attribute is set. This isn't the case here so it gets an IndexError. This change excepts the IndexError and stops the loop so the conversion doesn't stop.
