### PR TITLE
only add complete headrows to tablehead.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.3.8 (unreleased)
 ------------------
 
+- Don't add rows where not all cells are headcells to the tablehead.
+  [tschanzt]
+
 - Fix table converting when there are less cells than specified and no colspan attribute is given.
   [tschanzt]
 

--- a/ftw/pdfgenerator/html2latex/subconverters/table.py
+++ b/ftw/pdfgenerator/html2latex/subconverters/table.py
@@ -175,7 +175,7 @@ class TableConverter(subconverter.SubConverter):
 
         for row in self.rows:
             rowLatex = row.render()
-            if row.contains_head_cells():
+            if row.is_head_row():
                 head_rows.append(rowLatex)
             else:
                 body_rows.append(rowLatex)
@@ -459,11 +459,11 @@ class LatexRow(object):
     def register_cell(self, cell):
         self.cells.append(cell)
 
-    def contains_head_cells(self):
+    def is_head_row(self):
         for cell in self.cells:
-            if cell.is_head_cell():
-                return True
-        return False
+            if not cell.is_head_cell():
+                return False
+        return True
 
     def is_first_row(self):
         return self.table_converter.rows.index(self) == 0

--- a/ftw/pdfgenerator/tests/test_html2latex_table_converter.py
+++ b/ftw/pdfgenerator/tests/test_html2latex_table_converter.py
@@ -1589,6 +1589,44 @@ class TestTableConverter(MockTestCase):
         self.maxDiff = None
         self.assertMultiLineEqual(self.convert(html), latex)
 
+    def test_vertical_th_isnt_repeated(self):
+        html = '\n'.join((
+                r'<table class="plain" style="width: 100%;">',
+                r'  <colgroup>',
+                r'    <col width="17%" />',
+                r'    <col width="41%" />',
+                r'    <col width="35%" />',
+                r'  </colgroup>',
+                r'  <thead>',
+                r'    <tr>',
+                r'      <td style="width: 30%;">Foo</th>',
+                r'      <td style="width: 70%;">Bar</th>',
+                r'    </tr>',
+                r'   </thead>',
+                r'   <tbody>',
+                20 * r'    <tr><th style="width: 30%;">Foo</th><td style="width: 70%;">Batz</td></tr>',
+                r'  </tbody>',
+                r'</table>'))
+
+        latex_list = [
+            r'\makeatletter\@ifundefined{tablewidth}{\newlength\tablewidth}\makeatother',
+            r'\setlength\tablewidth\linewidth',
+            r'\addtolength\tablewidth{-4\tabcolsep}',
+            r'\renewcommand{\arraystretch}{1.4}',
+            r'\begin{longtable}{p{0.17\tablewidth}p{0.41\tablewidth}}',
+            r'\multicolumn{1}{p{0.3\tablewidth}}{\textbf{Foo}} & \multicolumn{1}{p{0.7\tablewidth}}{\textbf{Bar}} \\',
+            r'\endhead',
+        ]
+        for counter in range(20):
+            latex_list.append(r'\multicolumn{1}{p{0.3\tablewidth}}{\textbf{Foo}} & \multicolumn{1}{p{0.7\tablewidth}}{Batz} \\')
+        latex_list.append(r'\end{longtable}\\')
+        latex_list.append(r'\vspace{4pt}')
+        latex_list.append(r'')
+        latex = '\n'.join(latex_list)
+
+        self.maxDiff = None
+        self.assertMultiLineEqual(self.convert(html, use_packages=['longtable']), latex)
+
 
 class TestLatexWidth(TestCase):
 


### PR DESCRIPTION
If a table with vertical Headings such as this (all bold cells are headings)
<img width="968" alt="screen shot 2015-11-09 at 13 15 23" src="https://cloud.githubusercontent.com/assets/358342/11033545/4fe23d0c-86e4-11e5-9feb-8b40d348ac0e.png">

is given to the pdfgenerator it appends all rows to the tablehead, which can lead to strange effects in a table due to the fact, that all rows before the \endhead are repeated on every page. 
This Pr now only enters rows into the Head if all cells are headings.
@jone 