### PR TITLE
Drop Plone 4.1 support.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Drop Plone 4.1 support.
 
 
 1.5.0 (2016-06-08)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(name='ftw.pdfgenerator',
       classifiers=[
         "Environment :: Web Environment",
         'Framework :: Plone',
-        'Framework :: Plone :: 4.1',
         'Framework :: Plone :: 4.2',
         'Framework :: Plone :: 4.3',
         "Intended Audience :: Developers",

--- a/test-plone-4.1.x.cfg
+++ b/test-plone-4.1.x.cfg
@@ -1,6 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.1.x.cfg
-    sources.cfg
-
-package-name = ftw.pdfgenerator


### PR DESCRIPTION
Tests are failing, we are no longer supporting Plone 4.1.
