### PR TITLE
Support file objects in Builder.add_file.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,8 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
+- Support file objects in Builder.add_file. [jone]
+
 - Drop Plone 4.1 support.
 
 

--- a/ftw/pdfgenerator/builder.py
+++ b/ftw/pdfgenerator/builder.py
@@ -28,9 +28,11 @@ class Builder(object):
             raise BuildTerminated('The build is already terminated.')
 
         path = os.path.join(self.build_directory, filename)
-        file_ = open(path, 'wb')
-        file_.write(data)
-        file_.close()
+        with open(path, 'wb') as fio:
+            if hasattr(data, 'read'):
+                shutil.copyfileobj(data, fio)
+            else:
+                fio.write(data)
 
     def build(self, latex):
         if self._terminated:

--- a/ftw/pdfgenerator/tests/test_builder.py
+++ b/ftw/pdfgenerator/tests/test_builder.py
@@ -8,6 +8,7 @@ from ftw.pdfgenerator.interfaces import IBuilder, IBuilderFactory
 from ftw.pdfgenerator.testing import PREDEFINED_BUILD_DIRECTORY_LAYER
 from ftw.testing import MockTestCase
 from mocker import MATCH, ANY
+from StringIO import StringIO
 from zipfile import ZipFile
 from zope.component import getUtility
 from zope.interface.verify import verifyClass
@@ -45,6 +46,16 @@ class TestBuilder(MockTestCase):
     def test_add_file(self):
         builder = getUtility(IBuilderFactory)()
         builder.add_file('foo.txt', 'Foo\nBar')
+
+        self.assertTrue(os.path.exists(self.builddir))
+        filepath = os.path.join(self.builddir, 'foo.txt')
+        self.assertTrue(os.path.exists(filepath),
+                        'File not found: {0}'.format(filepath))
+        self.assertEqual(open(filepath).read(), 'Foo\nBar')
+
+    def test_add_file_by_file_object(self):
+        builder = getUtility(IBuilderFactory)()
+        builder.add_file('foo.txt', StringIO('Foo\nBar'))
 
         self.assertTrue(os.path.exists(self.builddir))
         filepath = os.path.join(self.builddir, 'foo.txt')


### PR DESCRIPTION
Update the Builder.add_file() to accept file objects so that we do not have to load all the data into the RAM at once.