### PR TITLE
Fixed exporting the zip and latex for pdfs who are setting the pdf title.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed exporting the zip and latex for pdfs who are setting the pdf title. [phgross]
 
 
 1.6.0 (2017-03-03)

--- a/ftw/pdfgenerator/assembler.py
+++ b/ftw/pdfgenerator/assembler.py
@@ -32,7 +32,7 @@ class PDFAssembler(object):
             return self._attach_to_response(
                 request, data, 'pdf', filename=filename)
 
-    def build_latex(self, layout=None, builder=None, request=None):
+    def build_latex(self, layout=None, builder=None, request=None, filename=None):
         self._layout = layout
         self._builder = builder
 
@@ -40,7 +40,7 @@ class PDFAssembler(object):
         self.get_builder().cleanup()
         return latex
 
-    def build_zip(self, layout=None, builder=None, request=None):
+    def build_zip(self, layout=None, builder=None, request=None, filename=None):
         self._layout = layout
         self._builder = builder
 
@@ -51,7 +51,7 @@ class PDFAssembler(object):
             return data
 
         else:
-            return self._attach_to_response(request, data, 'zip')
+            return self._attach_to_response(request, data, 'zip', filename=filename)
 
     def get_builder(self):
         """Returns the IBuilder instance.

--- a/ftw/pdfgenerator/tests/test_assembler.py
+++ b/ftw/pdfgenerator/tests/test_assembler.py
@@ -37,6 +37,24 @@ class TestPDFAssembler(MockTestCase):
         latex = obj.build_latex(layout=layout, builder=builder)
         self.assertEqual(latex, 'full latex')
 
+    def test_build_latex_parameters_with_fullname_parameter(self):
+        context = object()
+
+        layout = self.mocker.mock()
+        self.expect(layout.render_latex_for(context)).result('content latex')
+        self.expect(layout.render_latex('content latex')).result(
+            'full latex')
+
+        builder = self.mocker.mock()
+        self.expect(builder.cleanup())
+
+        self.replay()
+
+        obj = getMultiAdapter((context, object()), interfaces.IPDFAssembler)
+        latex = obj.build_latex(
+            layout=layout, builder=builder, filename='test')
+        self.assertEqual(latex, 'full latex')
+
     def test_use_filename_when_given(self):
         context = self.mocker.mock()
         layout = self.mocker.mock()
@@ -162,6 +180,31 @@ class TestPDFAssembler(MockTestCase):
         obj = getMultiAdapter((context, request), interfaces.IPDFAssembler)
         self.assertEqual(obj.build_zip(layout=layout, builder=builder,
                                        request=request),
+                         request)
+
+    def test_build_zip_with_filename_parameter(self):
+        context = self.stub()
+        self.expect(context.id, 'theid')
+
+        layout = self.mocker.mock()
+        self.expect(layout.render_latex_for(context)).result('content latex')
+        self.expect(layout.render_latex('content latex')).result(
+            'full latex')
+
+        builder = self.mocker.mock()
+        self.expect(builder.build_zip('full latex').read()).result('the zip')
+
+        request = self.mocker.mock()
+        response = self.mocker.mock()
+        self.expect(request.RESPONSE).result(response)
+        self.expect(response.setHeader(ARGS)).count(1, None)
+        self.expect(response.write('the zip'))
+
+        self.replay()
+
+        obj = getMultiAdapter((context, request), interfaces.IPDFAssembler)
+        self.assertEqual(obj.build_zip(layout=layout, builder=builder,
+                                       request=request, filename='my_pdf'),
                          request)
 
     def test_build_zip_with_no_request_returns_data(self):


### PR DESCRIPTION
With #48 an new keyword argument `filename` was introduced, unfortunately it was only accepted when downloading the pdf (`build_pdf`) otherwise downloading the latex/zip (`build_latex`/`build_zip`) it leads to an TypeError:
`TypeError: build_zip() got an unexpected keyword argument 'filename'`

This PR fixes that issue.