### PR TITLE
Add "Plone" to list of dependencies.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,8 @@ Changelog
 1.6.1 (unreleased)
 ------------------
 
+- Add "Plone" to list of dependencies. [mbaechtold]
+
 - Fixed exporting the zip and latex for pdfs who are setting the pdf title. [phgross]
 
 

--- a/ftw/pdfgenerator/html2latex/subconverters/url.py
+++ b/ftw/pdfgenerator/html2latex/subconverters/url.py
@@ -1,10 +1,6 @@
 from ftw.pdfgenerator.html2latex import subconverter
-from ftw.pdfgenerator.interfaces import HTML2LATEX_PREVENT_CHARACTER
-from Products.CMFCore.utils import getToolByName
 from urlparse import urlparse
 from urlparse import urlunparse
-import os.path
-import re
 
 
 class URLConverter(subconverter.SubConverter):

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(name='ftw.pdfgenerator',
         'zope.interface',
 
         # Plone
+        'Plone',
         'Products.Archetypes',
         'Products.CMFCore',
 


### PR DESCRIPTION
This makes the test suite no longer complain about the missing "Plone" distribution:

> DistributionNotFound: The 'Plone' distribution was not found and is required by the application