### PR TITLE
Fix encoding error by passing charset hint to BeautifulSoup when when converting tables

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,8 @@ Changelog
 1.6.1 (unreleased)
 ------------------
 
+- Fix encoding error by passing charset hint to BeautifulSoup when converting tables. [lgraf]
+
 - Add Plone 5 compatibility. [phgross]
 
 - Fixed exporting the zip and latex for pdfs who are setting the pdf title. [phgross]

--- a/ftw/pdfgenerator/html2latex/subconverters/table.py
+++ b/ftw/pdfgenerator/html2latex/subconverters/table.py
@@ -94,7 +94,7 @@ class TableConverter(subconverter.SubConverter):
     def parse(self):
         html = self.get_html()
         # cleanup html with BeautifulSoup
-        html = str(BeautifulSoup(html))
+        html = str(BeautifulSoup(html, fromEncoding='utf-8'))
         # minidom hates htmlentities, but loves xmlentities -.-
 
         html = html2xmlentities(html)

--- a/ftw/pdfgenerator/tests/test_html2latex_table_converter.py
+++ b/ftw/pdfgenerator/tests/test_html2latex_table_converter.py
@@ -68,6 +68,34 @@ class TestTableConverter(MockTestCase):
 
         self.assertMultiLineEqual(self.convert(html), latex)
 
+    def test_table_converted_with_non_ascii(self):
+        # Non-ASCII characters that *only* appear in table headings seem to
+        # trip up BeautifulSoups charset sniffing.
+        # This is a test case that would fail if BeautifulSoup was called
+        # without an appropriate charset hint (fromEncoding='utf-8')
+        html = '\n'.join((
+                '<table>',
+                '    <thead>',
+                '        <tr><th>B\xc3\xa4rengraben</th></tr>',
+                '    </thead><tbody>',
+                '        <tr><td>My Body</td></tr>',
+                '    </tbody>',
+                '</table>'))
+
+        latex = '\n'.join((
+                '\\makeatletter\\@ifundefined{tablewidth}{\\newlength\\tablewidth}\\makeatother',
+                '\\setlength\\tablewidth\\linewidth',
+                '\\addtolength\\tablewidth{-2\\tabcolsep}',
+                '\\renewcommand{\\arraystretch}{1.4}',
+                '\\begin{tabular}{l}',
+                '\\multicolumn{1}{l}{\\textbf{B\xc3\xa4rengraben}} \\\\',
+                '\\multicolumn{1}{l}{My Body} \\\\',
+                '\\end{tabular}\\\\',
+                '\\vspace{4pt}',
+                ''))
+
+        self.assertMultiLineEqual(self.convert(html), latex)
+
     def test_headings(self):
         html = '\n'.join((
                 r'<table>',


### PR DESCRIPTION
Fix encoding error by passing charset hint (`fromEncoding='utf-8')` to BeautifulSoup when converting tables:

Non-ASCII characters that *only* appear in table headings seem to trip up BeautifulSoups charset sniffing (I'm sure plenty of other things would as well). It's therefore important to pass a character set hint to BeautifulSoup, so it doesn't try to sniff the content / do any flawed charset detection that leads to Mojibake in the final LaTeX output.

This is especially true because we usually control the HTML input that ends up in `ftw.pdfgenerator`, so we don't really have a need for BeautifulSoup's charset sniffing.

Fixes 4teamwork/opengever.core#4315