### PR TITLE
Fix escaping issues for dash characters in hyperlink labels.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,8 +4,7 @@ Changelog
 1.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Fix escaping issues for dash characters in hyperlink labels. [jone]
 
 1.6.1 (2018-05-18)
 ------------------

--- a/ftw/pdfgenerator/html2latex/subconverters/hyperlink.py
+++ b/ftw/pdfgenerator/html2latex/subconverters/hyperlink.py
@@ -14,7 +14,8 @@ class HyperlinkConverter(subconverter.SubConverter):
         url, label = self.match.groups()
         label = (self.converter.convert(label)
                  .replace('""/', '/')
-                 .replace('_', '\_'))
+                 .replace('_', '\_')
+                 .replace('"=', '-'))
 
         is_relative = '://' not in url and not url.startswith('mailto:')
 

--- a/ftw/pdfgenerator/tests/test_html2latex_hyperlink_converter.py
+++ b/ftw/pdfgenerator/tests/test_html2latex_hyperlink_converter.py
@@ -187,6 +187,16 @@ class TestHyperlinkConverter(MockTestCase):
                               'url_label': 'http://foo'}
         self.assertEqual(self.convert(html), latex)
 
+    def test_no_escaped_dashes_in_label(self):
+        # In a \href{} environment, a-b should not become a"=b because
+        # this will be printend literal.
+        self.replay()
+        html = '<a href="http://foo">x-y</a>'
+        latex = LATEX_HREF % {'label': r'x-y',
+                              'url': 'http://foo',
+                              'url_label': 'http://foo'}
+        self.assertEqual(self.convert(html), latex)
+
     def test_removes_nonbreaking_spaces(self):
         self.replay()
         # Non break spaces are evil. In HTML they are usually not used the


### PR DESCRIPTION
We usually escape dashes (`x-` -> `x"=`) in order to control hyphenation.
In a `\href`-environment, the control sequence `"=` will be printed literal.
Therefore we must not use it in labels of hyperlinks.

Fixes #18