### PR TITLE
Handle vertical tab characters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ These TeX distributions are recommended:
 - Linux / Unix: `TeX Live`_
 - Windows: `MiKTeX`_
 
-The package is compatible with `Plone`_ 4.x.
+The package is compatible with `Plone`_ 4.3 and 5.1.
 
 
 Installing

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.6.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Handle vertical tab special character. [njohner]
 
 
 1.6.2 (2018-09-13)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 1.6.3 (unreleased)
 ------------------
 
+- Drop support for plone 4.2. [njohner]
 - Handle vertical tab special character. [njohner]
 
 

--- a/ftw/pdfgenerator/html2latex/patterns.py
+++ b/ftw/pdfgenerator/html2latex/patterns.py
@@ -15,6 +15,9 @@ DEFAULT_PATTERNS = ([
         (MODE_REPLACE,  '\\',                      BACKSLASH_MARKER),
         # remove ASCII non breaking space:
         (MODE_REPLACE,  '\xc2\xa0',                ' '),
+        # remove secial whitespace characters
+        (MODE_REPLACE,  '\x0b',                ' '),
+        (MODE_REPLACE,  '\x0c',                ' '),
         interfaces.HTML2LATEX_CUSTOM_PATTERN_PLACEHOLDER_TOP,
 
         # special characters

--- a/ftw/pdfgenerator/html2latex/patterns.py
+++ b/ftw/pdfgenerator/html2latex/patterns.py
@@ -15,8 +15,9 @@ DEFAULT_PATTERNS = ([
         (MODE_REPLACE,  '\\',                      BACKSLASH_MARKER),
         # remove ASCII non breaking space:
         (MODE_REPLACE,  '\xc2\xa0',                ' '),
-        # remove secial whitespace characters
+        # remove ASCII vertical tab control character
         (MODE_REPLACE,  '\x0b',                ' '),
+        # remove ASCII form feed control character
         (MODE_REPLACE,  '\x0c',                ' '),
         interfaces.HTML2LATEX_CUSTOM_PATTERN_PLACEHOLDER_TOP,
 

--- a/ftw/pdfgenerator/tests/test_html2latex_patterns.py
+++ b/ftw/pdfgenerator/tests/test_html2latex_patterns.py
@@ -119,8 +119,8 @@ class TestBasicPatterns(TestCase):
                          'foo \\textbf{"`bar"\'} baz')
 
     def test_whitespace(self):
-        self.assertEqual(self.convert('W\r\nX\nY\rZ'),
-                         'W X Y Z')
+        self.assertEqual(self.convert('U\x0bV\x0cW\r\nX\nY\rZ'),
+                         'U V W X Y Z')
 
         # Use short whitespace (\,) for abbreviation:
         self.assertEqual(self.convert('x e.g. y').strip(),

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(name='ftw.pdfgenerator',
       classifiers=[
         "Environment :: Web Environment",
         'Framework :: Plone',
-        'Framework :: Plone :: 4.2',
         'Framework :: Plone :: 4.3',
         'Framework :: Plone :: 5.1',
         "Intended Audience :: Developers",

--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -1,6 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
-    sources.cfg
-
-package-name = ftw.pdfgenerator


### PR DESCRIPTION
We add support for two more special whitespace characters (vertical tabs).
This issue appeared in https://extranet.4teamwork.ch/support/gever-st-gallen/tracker/493