### PR TITLE
Robustify URL conversion

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.6.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Robustified URL conversion. [Rotonen]
 
 
 1.6.3 (2019-01-07)

--- a/ftw/pdfgenerator/html2latex/subconverters/url.py
+++ b/ftw/pdfgenerator/html2latex/subconverters/url.py
@@ -1,15 +1,15 @@
 from ftw.pdfgenerator.html2latex import subconverter
-from ftw.pdfgenerator.interfaces import HTML2LATEX_PREVENT_CHARACTER
-from Products.CMFCore.utils import getToolByName
 from urlparse import urlparse
 from urlparse import urlunparse
-import os.path
-import re
 
 
 class URLConverter(subconverter.SubConverter):
-    """Converts URLs within text (not link tags) so that they
-    support hyphenation.
+    """Convert URLs within text (not link tags).
+
+    * Add hyphenation hints onto path segments
+    * Add hyphenation hints onto query string parametres
+    * Convert xml entities from minidom `element.toxml()`
+    * Escape latex nasties for link tags
     """
 
     # http://stackoverflow.com/questions/6883049/regex-to-find-urls-in-string-in-python
@@ -18,7 +18,25 @@ class URLConverter(subconverter.SubConverter):
     def __call__(self):
         url = self.get_html()
         scheme, netloc, path, params, query, fragment = urlparse(url)
-        path = path.replace('/', '""/')
+
+        # Make path segments hyphenable
+        path = '""/'.join(path.split('/'))
+
+        # Handle minidom `element.toxml()`
+        query = query.replace('&amp;', '&')
+
+        # Make query string parametres hyphenable
+        query = query.replace('&', '""&')
+
         url = urlunparse((scheme, netloc, path, params, query, fragment))
+
+        # Work around urlunparse() treating the hyphenation hint as a segment
         url = url.replace('/""/', '""/', 1)
+
+        # Replace latex nasties for conversion
+        url = url.replace('_', r'\_')
+        url = url.replace('&', r'\&')
+        url = url.replace('#', r'\#')
+        url = url.replace('%', r'\%')
+
         self.replace_and_lock(url)

--- a/ftw/pdfgenerator/tests/test_html2latex_url_converter.py
+++ b/ftw/pdfgenerator/tests/test_html2latex_url_converter.py
@@ -38,8 +38,12 @@ class TestURLConverter(MockTestCase):
 
     def test_advanced_url(self):
         self.replay()
-        html = 'x http://usr@pwd:sub.domain.com/path/to/doc.html' + \
-               '?foo=1&bar=2#anchor y'
-        latex = 'x http://usr@pwd:sub.domain.com""/path""/to""/doc.html' + \
-                '?foo=1&bar=2\\#anchor y'
+        html = 'x http://usr@pwd:sub.domain.com/path/to/doc.html?foo=1&bar=opt_2#anchor y'
+        latex = 'x http://usr@pwd:sub.domain.com""/path""/to""/doc.html?foo=1""\\&bar=opt\\_2\\#anchor y'
+        self.assertEqual(self.convert(html), latex)
+
+    def test_url_from_minidom(self):
+        self.replay()
+        html = 'https://example.com/some.php?get1=1234&amp;weird_get_%5Bbracketed%5D=5678&amp;somemore=blah'
+        latex = 'https://example.com""/some.php?get1=1234""\\&weird\\_get\\_\\%5Bbracketed\\%5D=5678""\\&somemore=blah'
         self.assertEqual(self.convert(html), latex)


### PR DESCRIPTION
Robustified the URL converter as it could otherwise produce non-latexable output when URLs are detected from outside hyperlinks.

Also made the hyphenation hints appear for query string segments, as very long tails would otherwise be unbreakable.

The implementation now somewhat follows the one from the hyperlink converter.

Part of: https://github.com/4teamwork/opengever.core/issues/5510