### PR TITLE
Fix underscore escaping in hyperlink label.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.6.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix escaping of underscore in hyperlink labels. [jone]
 
 
 1.6.4 (2019-03-26)

--- a/ftw/pdfgenerator/html2latex/subconverters/hyperlink.py
+++ b/ftw/pdfgenerator/html2latex/subconverters/hyperlink.py
@@ -14,7 +14,6 @@ class HyperlinkConverter(subconverter.SubConverter):
         url, label = self.match.groups()
         label = (self.converter.convert(label)
                  .replace('""/', '/')
-                 .replace('_', '\_')
                  .replace('"=', '-'))
 
         is_relative = '://' not in url and not url.startswith('mailto:')

--- a/ftw/pdfgenerator/tests/test_html2latex_hyperlink_converter.py
+++ b/ftw/pdfgenerator/tests/test_html2latex_hyperlink_converter.py
@@ -125,8 +125,15 @@ class TestHyperlinkConverter(MockTestCase):
         html = '<a href="http://host.com/foo_bar">baz</a>'
         latex = LATEX_HREF % {'label': 'baz',
                               'url': 'http://host.com/foo_bar',
-                              'url_label': 'http://host.com/foo\\_bar'}
+                              'url_label': 'http://host.com/foo\_bar'}
         self.assertEqual(self.convert(html), latex)
+
+    def test_underscores_in_links2(self):
+        self.replay()
+        html = '<a href="http://test.com/_something#anchor">http://test.com/_something#anchor</a>'
+        latex = r'\href{http://test.com/_something\#anchor}{http://test.com/\_something\#anchor\footnote{\href{http://test.com/_something\#anchor}{\url{http://test.com/\_something\#anchor}}}}'
+        self.assertMultiLineEqual(latex + '\n',
+                                  self.convert(html) + '\n')
 
     def test_hash_key_in_links(self):
         self.replay()


### PR DESCRIPTION
The label part of a `\href{url}{label}` type hyperlink was not escaped correctly regarding underscores.

The underscores were escaped with two backslashes (`\\_`). This escapes the slash, not the underscore. Which has the effect that an additional slash is added and the underscore is not escaped anymore.

This causes errors such as `! Missing $ inserted.`.

The fix is to only escape with one slash (`\_`).