### PR TITLE
Test mixed unicode/non-unicode strings and umlauts.

### DIFF
--- a/ftw/pdfgenerator/layout/baselayout.py
+++ b/ftw/pdfgenerator/layout/baselayout.py
@@ -1,3 +1,4 @@
+from Products.CMFDiffTool.utils import safe_utf8
 from ftw.pdfgenerator.babel import get_preferred_babel_option_for_context
 from ftw.pdfgenerator.exceptions import ConflictingUsePackageOrder
 from ftw.pdfgenerator.interfaces import IBuilder
@@ -232,6 +233,6 @@ class BaseLayout(object):
         latex = []
 
         for view in self.get_views_for(obj):
-            latex.append(view.render())
+            latex.append(safe_utf8(view.render()))
 
         return '\n'.join(latex)


### PR DESCRIPTION
It is handy if the method render_latex_for can handle mixed string lists (unicode/non-unicode) containing umlauts. This led to a error when exporting pdfs with prepended latex.

Close https://github.com/4teamwork/izug.organisation/issues/1820