### PR TITLE
Don't use session storage anymore - does not work with plone 5 for anonymous users

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.6.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Don't use session storage anymore - does not work with plone 5 for anonymous users. [mathias.leimgruber]
 
 
 1.6.6 (2020-01-17)

--- a/ftw/pdfgenerator/browser/views.py
+++ b/ftw/pdfgenerator/browser/views.py
@@ -1,7 +1,8 @@
-from Products.Five import BrowserView
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from ftw.pdfgenerator.interfaces import DEBUG_MODE_SESSION_KEY
 from ftw.pdfgenerator.interfaces import IPDFAssembler
+from plone import api
+from Products.Five import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.component import getMultiAdapter
 
 
@@ -30,6 +31,9 @@ class ExportPDFView(BrowserView):
         user = self.context.portal_membership.getAuthenticatedMember()
         if user.has_permission('cmf.ManagePortal', self.context):
             return True
+
+        elif api.user.is_anonymous():
+            return False
 
         elif self.request.SESSION.get(DEBUG_MODE_SESSION_KEY, False):
             return True

--- a/ftw/pdfgenerator/tests/test_export.py
+++ b/ftw/pdfgenerator/tests/test_export.py
@@ -100,17 +100,31 @@ class TestAsPDFView(MockTestCase):
         aspdf = ExportPDFView(context, request)
         self.assertEqual(aspdf.allow_alternate_output(), True)
 
-    def test_allow_alternate_output_False(self):
+    @patch('plone.api.user.is_anonymous')
+    def test_allow_alternate_output_False(self, is_anonymous):
+        is_anonymous.return_value = False
+
         context, request = self.mock_allow_alternate_output(False)
 
         aspdf = ExportPDFView(context, request)
         self.assertEqual(aspdf.allow_alternate_output(), False)
 
-    def test_allow_alternate_output_in_debug_mode_False(self):
+    @patch('plone.api.user.is_anonymous')
+    def test_allow_alternate_output_in_debug_mode_False(self, is_anonymous):
+        is_anonymous.return_value = False
         context, request = self.mock_allow_alternate_output(False, True)
 
         aspdf = ExportPDFView(context, request)
         self.assertEqual(aspdf.allow_alternate_output(), True)
+
+    @patch('plone.api.user.is_anonymous')
+    def test_do_not_allow_alternate_output_for_anonymous(self, is_anonymous):
+        is_anonymous.return_value = True
+
+        context, request = self.mock_allow_alternate_output(False)
+
+        aspdf = ExportPDFView(context, request)
+        self.assertEqual(aspdf.allow_alternate_output(), False)
 
     def test_call_renders_template_if_admin(self):
         context, request = self.mock_allow_alternate_output(True)
@@ -123,7 +137,9 @@ class TestAsPDFView(MockTestCase):
             aspdf = ExportPDFView(context, request)
             self.assertEqual(aspdf(), 'rendered html')
 
-    def test_call_exports_if_not_admin(self):
+    @patch('plone.api.user.is_anonymous')
+    def test_call_exports_if_not_admin(self, is_anonymous):
+        is_anonymous.return_value = False
         context, request = self.mock_allow_alternate_output(False)
         request_params = {
             'submitted': True,

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(name='ftw.pdfgenerator',
         # Plone
         'Products.Archetypes',
         'Products.CMFCore',
+        'plone.api',
 
         'Mako',
         'BeautifulSoup!=4.0b',


### PR DESCRIPTION

This fixes the following error:
```
POSKeyError: 0x09
  File "ZPublisher/Publish.py", line 138, in publish
    request, bind=1)
  File "ZPublisher/mapply.py", line 77, in mapply
    if debug is not None: return debug(object,args,context)
  File "ZPublisher/Publish.py", line 48, in call_object
    result=apply(object,args) # Type s<cr> to step into published object.
  File "home/zope/eggs/ftw.pdfgenerator-1.6.6-py2.7.egg/ftw/pdfgenerator/browser/views.py", line 17, in __call__
    if self.allow_alternate_output():
  File "home/zope/eggs/ftw.pdfgenerator-1.6.6-py2.7.egg/ftw/pdfgenerator/browser/views.py", line 34, in allow_alternate_output
    elif self.request.SESSION.get(DEBUG_MODE_SESSION_KEY, False):
  File "ZPublisher/HTTPRequest.py", line 1380, in __getattr__
    v = self.get(key, default, returnTaints=returnTaints)
  File "ZPublisher/HTTPRequest.py", line 1337, in get
    v = v()
  File "home/zope/eggs/Zope2-2.13.29-py2.7.egg/Products/Sessions/SessionDataManager.py", line 101, in getSessionData
    return self._getSessionDataObject(key)
  File "home/zope/eggs/Zope2-2.13.29-py2.7.egg/Products/Sessions/SessionDataManager.py", line 188, in _getSessionDataObject
    ob = container.new_or_existing(key)
  File "home/zope/eggs/Zope2-2.13.29-py2.7.egg/Products/Transience/Transience.py", line 839, in new_or_existing
    item = self.get(key, _marker)
  File "home/zope/eggs/Zope2-2.13.29-py2.7.egg/Products/Transience/Transience.py", line 495, in get
    item = self._move_item(k, current_ts, default)
  File "home/zope/eggs/Zope2-2.13.29-py2.7.egg/Products/Transience/Transience.py", line 285, in _move_item
    self._housekeep(current_ts)
  File "home/zope/eggs/Zope2-2.13.29-py2.7.egg/Products/Transience/Transience.py", line 934, in _housekeep
    self._finalize(now)
  File "home/zope/eggs/Zope2-2.13.29-py2.7.egg/Products/Transience/Transience.py", line 551, in _finalize
    last_finalized = self._last_finalized_timeslice()
  File "home/zope/eggs/Zope2-2.13.29-py2.7.egg/Products/Transience/Transience.py", line 1071, in __call__
    return self.value
  File "ZODB/Connection.py", line 796, in setstate
    p, serial = self._storage.load(oid)
  File "ZODB/mvccadapter.py", line 143, in load
    r = self._storage.loadBefore(oid, self._start)
  File "tempstorage/TemporaryStorage.py", line 187, in loadBefore
    raise POSException.POSKeyError(oid)
```

For more infos: see https://community.plone.org/t/sessions-and-poskeyerrors/5939/19
They recommend to use something else, like cookie storage. 