### PR TITLE
Add support for hexadecimal HTML entities

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.6.9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add support for converting hexadecimal XML/HTML entities [Nachtalb]
 
 
 1.6.8 (2020-02-11)

--- a/ftw/pdfgenerator/html2latex/subconverters/htmlentities.py
+++ b/ftw/pdfgenerator/html2latex/subconverters/htmlentities.py
@@ -5,6 +5,7 @@ from ftw.pdfgenerator.utils import decode_htmlentities
 
 class HtmlentitiesConverter(subconverter.SubConverter):
 
+    # e.g. Matches named "&auml;", numeric "&#13;" and hexadecimal "&#xE4;" entities
     pattern = r'\\?&\\?(#?)(\d{1,5}|\w{1,8}|x[\w\d]{1,5});'
     placeholder = interfaces.HTML2LATEX_CUSTOM_PATTERN_PLACEHOLDER_BOTTOM
 

--- a/ftw/pdfgenerator/html2latex/subconverters/htmlentities.py
+++ b/ftw/pdfgenerator/html2latex/subconverters/htmlentities.py
@@ -5,10 +5,10 @@ from ftw.pdfgenerator.utils import decode_htmlentities
 
 class HtmlentitiesConverter(subconverter.SubConverter):
 
-    pattern = r'\\&(\w*);'
+    pattern = r'\\?&\\?(#?)(\d{1,5}|\w{1,8}|x[\w\d]{1,5});'
     placeholder = interfaces.HTML2LATEX_CUSTOM_PATTERN_PLACEHOLDER_BOTTOM
 
     def __call__(self):
-        html = self.get_html()[1:]
+        html = self.get_html()
         latex = decode_htmlentities(html).encode('utf8')
         self.replace(latex)

--- a/ftw/pdfgenerator/tests/test_html2latex_htmlentities_converter.py
+++ b/ftw/pdfgenerator/tests/test_html2latex_htmlentities_converter.py
@@ -2,7 +2,6 @@ from ftw.pdfgenerator.html2latex.subconverters import htmlentities
 from ftw.pdfgenerator.tests.base import SubconverterTestBase
 
 
-
 class TestHtmlentitiesConverter(SubconverterTestBase):
 
     def test_converter_is_default(self):
@@ -15,6 +14,8 @@ class TestHtmlentitiesConverter(SubconverterTestBase):
                          '\xc3\xa4\xc3\xab\xc3\xaf\xc3\xb6\xc3\xbc')
         self.assertEqual(self.convert('5 &lt; 6'),
                          '5 < 6')
+        self.assertEqual(self.convert('7 &#x3E; 6'),
+                         '7 > 6')
         self.assertEqual(self.convert('Hello&nbsp;World'),
                          'Hello World')
 

--- a/ftw/pdfgenerator/tests/test_utils.py
+++ b/ftw/pdfgenerator/tests/test_utils.py
@@ -84,7 +84,7 @@ class TestEntities(TestCase):
     def test_decode_htmlentites(self):
         self.assertEqual(utils.decode_htmlentities('&quot;X&gt;Y&quot;'),
                          u'"X>Y"')
-        self.assertEqual(utils.decode_htmlentities('m&#38;m'),
+        self.assertEqual(utils.decode_htmlentities('m&#x26;m'),
                          u'm&m')
         self.assertEqual(utils.decode_htmlentities('a&foo;b'),
                          u'a&foo;b')
@@ -110,6 +110,10 @@ class TestEntities(TestCase):
     def test_xml2htmlentities(self):
         self.assertEqual(utils.xml2htmlentities('m&#38;m'),
                          'm&amp;m')
+        self.assertEqual(utils.xml2htmlentities('m&#xE4;m'),
+                         'm&auml;m')
+        self.assertEqual(utils.xml2htmlentities('m&#xFFF;m'),
+                         'm&#xFFF;m')
         self.assertEqual(utils.xml2htmlentities('a&#9999;b'),
                          'a&#9999;b')
 

--- a/ftw/pdfgenerator/utils.py
+++ b/ftw/pdfgenerator/utils.py
@@ -38,11 +38,15 @@ def decode_htmlentities(string):
     """
     Decodes html entities and xml entities.
     """
-    entity_re = re.compile("&(#?)(\d{1,5}|\w{1,8});")
+    entity_re = re.compile("\\\?&\\\?(#?)(\d{1,5}|\w{1,8}|x[\w\d]{1,5});")
 
     def substitute_entity(match):
         ent = match.group(2)
+
         if match.group(1) == "#":
+            if ent.startswith('x'):
+                ent = int('0%s' % ent, 16)  # hex to decimal
+
             return unichr(int(ent))
 
         else:
@@ -81,7 +85,7 @@ def encode_htmlentities(string, encoding='utf-8'):
 
 def html2xmlentities(string):
     """
-    Converts htmlentities to xmlentities
+    Converts htmlentities to xmlentities (decimal)
     """
 
     xpr = re.compile('&(\w{1,8});')
@@ -99,12 +103,18 @@ def html2xmlentities(string):
 
 def xml2htmlentities(string):
     """
-    Converts xmlentities to htmlentities
+    Converts xmlentities (decimal and hex) to htmlentities
     """
-    xpr = re.compile('&#(\d{1,5});')
+    xpr = re.compile('&#(\d{1,5}|x[\d\w]{1,5});')
 
     def substitute_entity(match):
-        ent = int(match.group(1))
+        ent = match.group(1)
+
+        if ent.startswith('x'):
+            ent = int('0%s' % ent, 16)  # hex to decimal
+        else:
+            ent = int(ent)
+
         if ent in cp2n.keys():
             return '&%s;' % cp2n[ent]
 

--- a/ftw/pdfgenerator/utils.py
+++ b/ftw/pdfgenerator/utils.py
@@ -38,6 +38,8 @@ def decode_htmlentities(string):
     """
     Decodes html entities and xml entities.
     """
+
+    # e.g. Matches named "&auml;", numeric "&#13;" and hexadecimal "&#xE4;" entities
     entity_re = re.compile("\\\?&\\\?(#?)(\d{1,5}|\w{1,8}|x[\w\d]{1,5});")
 
     def substitute_entity(match):
@@ -105,6 +107,8 @@ def xml2htmlentities(string):
     """
     Converts xmlentities (decimal and hex) to htmlentities
     """
+
+    # e.g. Matches named "&auml;", numeric "&#13;" and hexadecimal "&#xE4;" entities
     xpr = re.compile('&#(\d{1,5}|x[\d\w]{1,5});')
 
     def substitute_entity(match):


### PR DESCRIPTION
Add support for hexadecimal HTML entities in addition to decimal and named HTML entities.

https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Character_reference_overview

Fixes https://github.com/4teamwork/ftw.book/issues/126, https://github.com/4teamwork/izug.organisation/issues/1914